### PR TITLE
fix: update travis to remove Node.js 8 which is EOL in 3 months

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '12'
 before_script:

--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '12'
 before_script:


### PR DESCRIPTION
Remove Node.js 8 which is EOL on Jan 2020 from CI job matrix