### PR TITLE
fix: remove deprecated Snyk vulnerabilities badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
   <a href="https://www.npmjs.org/package/create-node-lib"><img src="https://badgen.net/npm/v/create-node-lib"alt="npm version"/></a>
   <a href="https://www.npmjs.org/package/create-node-lib"><img src="https://badgen.net/npm/license/create-node-lib"alt="license"/></a>
   <a href="https://www.npmjs.org/package/create-node-lib"><img src="https://badgen.net/npm/dt/create-node-lib"alt="downloads"/></a>
-  <a href="https://snyk.io/test/github/lirantal/create-node-lib"><img src="https://snyk.io/test/github/lirantal/create-node-lib/badge.svg" alt="Known Vulnerabilities"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Responsible Disclosure Policy" /></a>
   <a href="https://github.com/saojs/awesome-sao"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome"/></a>
   <a href="https://snyk.io/advisor/npm-package/create-node-lib"><img src="https://snyk.io/advisor/npm-package/create-node-lib/badge.svg" alt="create-node-lib"></a>


### PR DESCRIPTION
The Snyk vulnerabilities badge (`snyk.io/test/github/...`) has been deprecated and no longer renders correctly. Removing it from the README so the badge row stays clean.