### PR TITLE
fix: exclude pnpm-workspace.yaml when npm is selected as package manager

### DIFF
--- a/__tests__/generator.test.js
+++ b/__tests__/generator.test.js
@@ -79,6 +79,28 @@ describe('all the template files are accountable for', () => {
     expect(pkg.scripts['lint:lockfile']).toEqual(mockScripts['lint:lockfile'])
   })
 
+  test('Generator includes pnpm-workspace.yaml when pnpm is selected', async () => {
+    const stream = await sao.mock(
+      { generator: template },
+      {
+        npmClient: 'pnpm'
+      }
+    )
+
+    expect(stream.fileList).toContain('pnpm-workspace.yaml')
+  })
+
+  test('Generator excludes pnpm-workspace.yaml when npm is selected', async () => {
+    const stream = await sao.mock(
+      { generator: template },
+      {
+        npmClient: 'npm'
+      }
+    )
+
+    expect(stream.fileList).not.toContain('pnpm-workspace.yaml')
+  })
+
   test('Generator input creates correct package.json scripts with npm as client', async () => {
     const mockScripts = {
       'lint:lockfile': 'lockfile-lint --path package-lock.json --validate-https --allowed-hosts npm'

--- a/saofile.js
+++ b/saofile.js
@@ -115,7 +115,15 @@ module.exports = {
           gitignore: '.gitignore',
           npmrc: '.npmrc'
         }
-      }
+      },
+      ...(npmClient !== 'pnpm'
+        ? [
+            {
+              type: 'remove',
+              files: 'pnpm-workspace.yaml'
+            }
+          ]
+        : [])
     ]
   },
   async completed() {


### PR DESCRIPTION
The pnpm-workspace.yaml template file was always copied to the scaffolded project regardless of the chosen package manager. It is now removed from the output when the user selects npm.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
