### PR TITLE
fix: move package manager constraints to engines

### DIFF
--- a/__tests__/generator.test.js
+++ b/__tests__/generator.test.js
@@ -75,6 +75,9 @@ describe('all the template files are accountable for', () => {
     expect(pkg.author.email).toBe(mockUserEmail)
     expect(pkg.homepage).toBe(mockProjectRepository)
     expect(pkg.keywords).toEqual(mockProjectKeywords)
+    expect(pkg.engines.pnpm).toBe('>=10.26.0')
+    expect(pkg.engines.npm).toBeUndefined()
+    expect(pkg.packageManager).toBeUndefined()
     // Testing only variable scripts
     expect(pkg.scripts['lint:lockfile']).toEqual(mockScripts['lint:lockfile'])
   })
@@ -116,6 +119,9 @@ describe('all the template files are accountable for', () => {
     const pkg = JSON.parse(await stream.readFile('package.json'))
     // Testing only variable scripts
     expect(pkg.scripts['lint:lockfile']).toEqual(mockScripts['lint:lockfile'])
+    expect(pkg.engines.npm).toBe('>=11.10.0')
+    expect(pkg.engines.pnpm).toBeUndefined()
+    expect(pkg.packageManager).toBeUndefined()
   })
 
   test('Generator creates package.json with prepare script for husky', async () => {

--- a/saofile.js
+++ b/saofile.js
@@ -1,7 +1,11 @@
 'use strict'
 const validateNpmPackageName = require('validate-npm-package-name')
 
-const SUPPORTED_NPM_CLIENTS = ['pnpm', 'npm']
+const PACKAGE_MANAGER_ENGINES = {
+  pnpm: '>=10.26.0',
+  npm: '>=11.10.0'
+}
+const SUPPORTED_NPM_CLIENTS = Object.keys(PACKAGE_MANAGER_ENGINES)
 
 module.exports = {
   description: 'Scaffolding out a node library.',
@@ -100,11 +104,9 @@ module.exports = {
             'lint:lockfile'
           ] = `lockfile-lint --path ${lockfile} --validate-https --allowed-hosts npm`
           data.scripts['lint'] = `eslint . && ${npmClient} run lint:lockfile && ${npmClient} run lint:markdown`
+          data.engines[npmClient] = PACKAGE_MANAGER_ENGINES[npmClient]
           data['lint-staged'] = {
             '**/*.{js,json}': [`${npmClient} run lint:fix`]
-          }
-          if (npmClient !== 'pnpm') {
-            delete data.packageManager
           }
           return data
         }

--- a/template/package.json
+++ b/template/package.json
@@ -28,7 +28,6 @@
   "engines": {
     "node": ">=24.0.0"
   },
-  "packageManager": "pnpm@10.31.0",
   "files": [
     "dist",
     "src",


### PR DESCRIPTION
## Summary
- Remove the hardcoded pnpm `packageManager` field from the generated template.
- Add the selected package manager version range to `engines` for pnpm and npm projects.
- Cover the generated pnpm/npm engine behavior in generator tests.

## Test plan
- [x] npm test


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move package manager constraints into `engines` in the generated `package.json`, removing the hardcoded `packageManager`. Sets the selected package manager range and updates tests.

- **Bug Fixes**
  - Add `engines.pnpm` as `>=10.26.0` or `engines.npm` as `>=11.10.0` based on selection.
  - Remove `packageManager` from the template.
  - Update generator tests to assert the new `engines` behavior.

<sup>Written for commit 8877e9730c7d1264dfa383f2b654fc163bf489d5. Summary will update on new commits. <a href="https://cubic.dev/pr/lirantal/create-node-lib/pull/48?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

