### PR TITLE
chore: replace deprecated tsconfig baseUrl with paths + types

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -7,10 +7,17 @@
     "allowJs": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": [
+      "node"
+    ],
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
     "target": "ES2022",
-    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
     "noEmit": true,
     "rootDir": "./src",
     "declaration": true,


### PR DESCRIPTION
TypeScript 6 started failing the CI build with `TS5101` because `compilerOptions.baseUrl` is now deprecated and scheduled to stop working in TypeScript 7. This change removes the deprecated setting and migrates the project to an explicit alias-based configuration.

- **Problem**
  - `tsc` fails on `tsconfig.json` due to deprecated `baseUrl`.
  - The repo was not relying on root-based imports today, but the deprecated setting still blocked the build after the TypeScript upgrade.

- **Config migration**
  - remove `compilerOptions.baseUrl`
  - add an explicit alias mapping via `compilerOptions.paths`
  - keep module resolution aligned with the current Node/ESM setup

- **Type resolution**
  - add `types: ["node"]` so Node built-ins continue resolving cleanly under the updated config

- **Result**
  - the project no longer depends on deprecated `baseUrl` behavior
  - future internal imports can use an explicit alias instead of implicit root lookup

```json
{
  "compilerOptions": {
    "types": ["node"],
    "paths": {
      "@/*": ["./src/*"]
    }
  }
}
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks CI on TypeScript 6 (`TS5101`) by migrating to an alias-based `tsconfig` and ensuring Node built-ins resolve. Node/ESM module resolution remains unchanged.

- **Refactors**
  - Remove deprecated `compilerOptions.baseUrl` in `tsconfig.json`.
  - Add `compilerOptions.paths` alias: `@/*` -> `./src/*`.
  - Set `types: ["node"]` for built-in type resolution.
  - Keep `moduleResolution` and `module` as `NodeNext`.

<sup>Written for commit 582b6c672fd5ae30409fdaf65c9cc47e50750386. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/create-node-lib/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

