### PR TITLE
build: align template ESLint 10 toolchain with gh-cp#29

### DIFF
--- a/template/eslint.config.js
+++ b/template/eslint.config.js
@@ -6,6 +6,7 @@ import tseslint from 'typescript-eslint'
 
 export default defineConfig([
   globalIgnores([
+    '__tests__/**/*.ts',
     'dist/**',
     'coverage/**',
     'node_modules/**',

--- a/template/package.json
+++ b/template/package.json
@@ -70,8 +70,8 @@
     "url": "<%= projectRepository %>.git"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.5.0",
-    "@changesets/cli": "^2.27.7",
+    "@changesets/changelog-github": "^0.6.0",
+    "@changesets/cli": "^2.31.0",
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.5.0",
     "c8": "^11.0.0",
@@ -81,7 +81,7 @@
     "husky": "^9.0.11",
     "lint-staged": "^16.2.7",
     "markdownlint-cli": "0.48.0",
-    "tsdown": "^0.21.5",
+    "tsdown": "^0.21.10",
     "tsx": "^4.19.4",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.59.0",


### PR DESCRIPTION
## Summary

The template was already migrated to the ESLint 10 flat config (per `docs/migrations/MIGRATION-GUIDE-ESLINT-10-TOOLCHAIN.md`). This fills the remaining gaps so a freshly scaffolded project is **green out of the box** and fully matches [lirantal/gh-cp#29](https://github.com/lirantal/gh-cp/pull/29).

### Fixes
- **`template/eslint.config.js`** — restore the `'__tests__/**/*.ts'` entry in `globalIgnores`. gh-cp#29 ignores test files; the template's migration dropped it, so a scaffolded project's `eslint .` **fails immediately** on the example test's unused `t` parameter (`@typescript-eslint/no-unused-vars`). Confirmed by scaffolding + linting.
- **`template/package.json`** — bring the incidental dev-tooling versions in line with gh-cp#29: `@changesets/changelog-github` `^0.5.0`→`^0.6.0`, `@changesets/cli` `^2.27.7`→`^2.31.0`, `tsdown` `^0.21.5`→`^0.21.10`.

### Already correct (no change needed)
ESLint 10 flat config + `@eslint/js`/`typescript-eslint`/`eslint-plugin-n`/`eslint-plugin-security`, `eslint`@^10.2.1, `c8`@^11, `neostandard` and `lockfile-lint` removed, generator (`saofile.js`) lint-script wiring, and `pnpm-workspace.yaml` hardening.

### Verification
Scaffolded the template (placeholders filled) and ran in an isolated, credential-free container honoring the template's `minimumReleaseAge`/`trustPolicy`:
- `pnpm install` ✅
- `eslint .` ✅ (was ❌ on the example test before this change)
- `pnpm run build` ✅
- `pnpm test` ✅ (1/1)

The generator test asserts file presence + changeset `$schema` only (not dep versions), so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the template ESLint 10 flat-config toolchain with gh-cp#29 so scaffolded projects are green out of the box.

- **Bug Fixes**
  - Add `'__tests__/**/*.ts'` to `globalIgnores` in `template/eslint.config.js` to prevent lint errors on the example test.

- **Dependencies**
  - `@changesets/changelog-github` → `^0.6.0`
  - `@changesets/cli` → `^2.31.0`
  - `tsdown` → `^0.21.10`

<sup>Written for commit e31044105518ee25f94a4653912fa90b8dfe9910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/create-node-lib/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

