### PR TITLE
docs: add repository context docs 🤖🤖🤖

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,106 +1,35 @@
 # AGENTS.md
 
-## Project Overview
+Guidance for AI coding agents working in this repository.
 
-**create-node-lib** is a scaffolding CLI tool that generates batteries-included Node.js library projects. Users run `npx create-node-lib my-lib-name` (or `pnpm create node-lib my-lib-name`), answer interactive prompts, and get a fully configured project with TypeScript, testing, linting, CI/CD, changesets, and git hooks.
+## Start Here
 
-## Architecture
+Before making changes, read:
 
-The project has two distinct layers:
+- `CONTRIBUTING.md` for contribution, PR, testing, commit, and agent-specific expectations.
+- `RELEASE.md` for release workflow details.
+- `README.md` for user-facing behavior, install/use examples, and package or app overview.
+- `docs/README.md` for the project documentation index.
+- `docs/development.md` for local setup and development workflows.
+- `docs/testing.md` for test strategy, commands, and verification expectations.
+- `docs/architecture.md` for project structure, boundaries, and important invariants.
+- `docs/conventions.md` for project-specific coding, documentation, and maintenance conventions.
 
-### 1. Generator (root level)
+Treat those files as the source of truth. Do not duplicate or reinterpret their rules here.
 
-The scaffolding engine that prompts users and generates projects:
+## Documentation
 
-- **`bin/cli.js`** — CLI entry point. Resolves the generator root and output directory, then delegates to Sao.
-- **`saofile.js`** — Generator definition. Contains prompts, template data helpers, file actions, and post-generation hooks (git init, npm install, husky setup).
-- **`__tests__/generator.test.js`** — Jest tests that use `sao.mock()` to verify generated file lists and content.
+- Keep documentation in sync when changing behavior, public interfaces, workflows, architecture, configuration, or operational assumptions.
+- Put project-specific development details in `docs/`; keep root files focused on their standard audiences.
+- Prefer linking to the source of truth over duplicating long instructions across files.
+- When adding new docs, link them from `docs/README.md` and update this file only when they become important entry points for future agents.
 
-### 2. Template (`template/` directory)
+## PRs and Issues
 
-The EJS template files that become the generated project. These use placeholders like `<%= projectName %>`, `<%= author %>`, `<%= email %>`, `<%= username %>`, `<%= projectRepository %>`, and helpers like `<%= npmClientInstall(npmClient) %>` and `<%- changesetRepo({ projectRepository }) %>`.
+- Follow PR, issue, and agent-labeling rules in `CONTRIBUTING.md`.
+- Use the issue-linking format specified in `CONTRIBUTING.md`.
 
-The generated project includes:
-- TypeScript source in `src/` with dual ESM/CJS output via tsdown
-- Node.js built-in test runner with c8 coverage
-- ESLint (neostandard) + eslint-plugin-security + Prettier
-- Changesets for versioning and releases
-- Husky git hooks with conventional commits
-- GitHub Actions workflows for CI, releases, link checking, and more
+## Releases
 
-## Tech Stack
-
-| Layer     | Technology                                                    |
-|-----------|---------------------------------------------------------------|
-| Scaffolding | Sao v1.7.1                                                 |
-| Validation  | validate-npm-package-name                                  |
-| Testing     | Jest 29 (generator), Node.js test runner + c8 (template)   |
-| Linting     | ESLint (standard config for generator, neostandard for template) |
-| Formatting  | Prettier                                                    |
-| Releases    | semantic-release (generator), Changesets (template)         |
-| Git hooks   | Husky + lint-staged + commitlint/validate-conventional-commit |
-| Language    | JavaScript (generator), TypeScript (template)               |
-
-## Commands
-
-### Generator (root)
-
-| Command | Purpose |
-|---------|---------|
-| `npm test` | Run Jest tests |
-| `npm run test:watch` | Jest in watch mode |
-| `npm run lint` | ESLint + lockfile-lint |
-| `npm run lint:fix` | ESLint with auto-fix |
-| `npm run format` | Prettier on all JS files |
-
-### Template (generated project)
-
-| Command | Purpose |
-|---------|---------|
-| `npm run build` | `tsc && tsdown` — compile TypeScript to ESM + CJS |
-| `npm test` | `c8 node --import tsx --test` — run tests with coverage |
-| `npm run lint` | ESLint + lockfile-lint + markdownlint |
-| `npm run lint:fix` | ESLint with auto-fix |
-| `npm start` | Run CLI via tsx |
-
-## Code Style
-
-- **Prettier**: 100 char print width, 2-space indent, single quotes, no semicolons, no trailing commas
-- **ESLint**: Standard-style rules (generator uses eslint-config-standard; template uses neostandard)
-- **Security**: eslint-plugin-security is enabled in both layers
-- **Commits**: Conventional commit format enforced via git hooks
-- **CommonJS**: The generator itself (`bin/cli.js`, `saofile.js`, tests) uses CommonJS (`require`/`module.exports`)
-- **ESM + TypeScript**: The template generates ESM-first TypeScript projects
-
-## File Conventions
-
-- Generator source files are plain JavaScript at the root level — no transpilation step
-- Template files in `template/` are EJS templates — be careful not to break `<%= ... %>` and `<%- ... %>` placeholders when editing
-- Test files live in `__tests__/` directories (both generator and template)
-- The template's `package.json` uses EJS interpolation for project metadata fields
-
-## Testing
-
-Generator tests use `sao.mock()` to run the generator with mocked prompt answers and assert on:
-- The generated file list (`stream.fileList`)
-- The content of generated files (`stream.readFile()`)
-- Correct template variable substitution
-
-Run tests before committing: `npm test`
-
-## CI/CD
-
-The generator's CI (`.github/workflows/main.yml`) runs on push and PR:
-- Tests on Node.js 24, Ubuntu
-- On push to `main`, runs `semantic-release` to publish to npm
-
-## Key Considerations for Agents
-
-1. **Two-layer architecture**: Changes to the generator logic go in `saofile.js` or `bin/cli.js`. Changes to what gets generated go in `template/`.
-2. **EJS templates**: Files in `template/` are EJS — angle-bracket placeholders (`<%= %>`, `<%- %>`) are intentional and must be preserved.
-3. **Template helpers**: `templateData` in `saofile.js` defines helper functions (`npmClientInstall`, `changesetRepo`) available in templates.
-4. **Sao framework**: The generator uses Sao v1 — refer to Sao v1 docs for the `prompts`, `actions`, `completed` lifecycle.
-5. **No TypeScript at root**: The generator itself is plain JavaScript with CommonJS modules. Only the template output is TypeScript.
-6. **Test with mocks**: Generator tests don't actually create files on disk — they use `sao.mock()` to simulate generation.
-7. **Lockfile-lint**: Both the generator and template validate lockfiles — if you change the package manager config, update the lint:lockfile script accordingly.
-8. **Package managers**: The supported package managers are pnpm (default/recommended) and npm. Yarn is not supported. The `saofile.js` `actions()` handler dynamically sets the `lint:lockfile` script to use `pnpm-lock.yaml` or `package-lock.json` based on the user's choice.
+- Follow `RELEASE.md` for release workflow and changeset creation steps.
+- If this project uses changesets, treat `RELEASE.md` and any changeset guidance in `CONTRIBUTING.md` as authoritative.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ Please consult [CONTRIBUTING](./CONTRIBUTING.md) for guidelines on contributing 
 # Author
 
 **create-node-lib** © [Liran Tal](https://github.com/lirantal), Released under the [Apache-2.0](./LICENSE) License.
+
+## Documentation
+
+- [Project documentation](./docs/README.md) - development, testing, architecture, and conventions.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+# Release
+
+This project uses [Changesets](https://github.com/changesets/changesets) for versioning and release notes.
+
+## Release Flow
+
+1. Ensure all intended changes are merged and CI is green.
+2. Run `npm run version` to apply Changesets version and changelog updates.
+3. Review the generated package and changelog changes.
+4. Run the release command, if configured for the repository.
+
+No root `release` script is currently defined. Use the repository's publishing workflow or add one before publishing.
+
+## Changesets
+
+Add a changeset for user-facing package behavior changes:
+
+```sh
+npm run changeset
+```
+
+Documentation-only, test-only, and internal refactor PRs usually do not need a changeset unless they describe or accompany a release-worthy behavior change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# create-node-lib Documentation
+
+This directory contains project documentation for maintainers and coding agents.
+
+## Core Docs
+
+- [Development](./development.md) - local setup, workflows, and useful commands.
+- [Testing](./testing.md) - test commands, test organization, and verification expectations.
+- [Architecture](./architecture.md) - repository structure, package boundaries, and important flows.
+- [Conventions](./conventions.md) - coding, documentation, and maintenance conventions.
+
+## Root References
+
+- [Project README](../README.md) - user-facing overview, installation, and usage.
+- [Contributing](../CONTRIBUTING.md) - issue, PR, commit, and agent expectations.
+- [Release](../RELEASE.md) - Changesets and release workflow.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,18 @@
+# Architecture
+
+## Overview
+
+create-node-lib package description: Scaffolding out a Node.js library module.
+
+## Repository Structure
+
+- `package.json` - root package scripts and dependency metadata.
+- `.changeset/` - Changesets configuration and pending release notes.
+- `docs/` - project documentation for maintainers and coding agents.
+
+## Boundaries
+
+- Keep user-facing usage, installation, and examples in the root `README.md`.
+- Keep contribution rules in `CONTRIBUTING.md`.
+- Keep release workflow details in `RELEASE.md`.
+- Keep deeper development and architecture notes in `docs/`.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,20 @@
+# Conventions
+
+## Commits and PRs
+
+- Use Conventional Commits for commit messages.
+- Keep PRs focused on one logical change.
+- Include a Changeset for release-worthy package behavior changes.
+- Agent-authored PRs should follow the repository's agent title marker guidance in `CONTRIBUTING.md`.
+
+## Documentation
+
+- Keep root `README.md` focused on users and package consumers.
+- Put maintainer and agent context in `docs/`.
+- Link new documentation from `docs/README.md`.
+
+## Code
+
+- Prefer the existing package structure and scripts over introducing new tooling.
+- Keep generated files, dependency folders, and build output out of commits.
+- Match formatting and lint expectations already configured in the repository.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,22 @@
+# Development
+
+## Prerequisites
+
+- Node.js compatible with this repository's packages and tooling.
+- npm for dependency installation and scripts.
+
+## Setup
+
+```sh
+npm install
+```
+
+## Common Commands
+
+- `pnpm lint` - runs lint checks.
+- `pnpm test` - runs the test suite.
+- `pnpm format` - formats supported files.
+
+## Repository Notes
+
+This repository is organized around the root package `create-node-lib`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,24 @@
+# Testing
+
+## Test Command
+
+Run the test suite with:
+
+```sh
+npm run test
+```
+
+## Linting
+
+Run lint checks with:
+
+```sh
+npm run lint
+```
+
+
+## Expectations
+
+- Add or update tests for behavior changes.
+- Run the relevant package-level checks before opening a PR.
+- Keep generated coverage, build output, and dependency folders out of commits.


### PR DESCRIPTION
Adds standardized repository context for coding agents and maintainers:

- refreshes AGENTS.md with the shared routing template
- adds or links canonical docs for development, testing, architecture, and conventions
- adds RELEASE.md where missing for Changesets release guidance

No package behavior changes are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes repository context and guidance for maintainers and coding agents in `create-node-lib`. No package behavior changes.

- **Refactors**
  - Rewrote `AGENTS.md` to route agents to source-of-truth docs.
  - Added `docs/README.md` and core docs: `development.md`, `testing.md`, `architecture.md`, `conventions.md`.
  - Added `RELEASE.md` with Changesets release guidance.
  - Linked docs from `README.md`.

<sup>Written for commit de8fee4628f7a38c8b56abbc26f17002ec2095df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/create-node-lib/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

