### PR TITLE
fix: generate portable husky hooks

### DIFF
--- a/__tests__/generator.test.js
+++ b/__tests__/generator.test.js
@@ -122,6 +122,26 @@ describe('all the template files are accountable for', () => {
     expect(pkg.scripts.prepare).toBe('husky')
   })
 
+  test('Generator creates package-manager aware husky hooks', async () => {
+    const pnpmStream = await sao.mock(
+      { generator: template },
+      {
+        npmClient: 'pnpm'
+      }
+    )
+    const npmStream = await sao.mock(
+      { generator: template },
+      {
+        npmClient: 'npm'
+      }
+    )
+
+    expect(await pnpmStream.readFile('.husky/commit-msg')).toBe('pnpm exec validate-conventional-commit < "$1"\n')
+    expect(await pnpmStream.readFile('.husky/pre-commit')).toBe('pnpm exec lint-staged\n')
+    expect(await npmStream.readFile('.husky/commit-msg')).toBe('npm exec validate-conventional-commit < "$1"\n')
+    expect(await npmStream.readFile('.husky/pre-commit')).toBe('npm exec lint-staged\n')
+  })
+
   test('Generator creates changeset config.json file', async () => {
     const stream = await sao.mock({ generator: template })
     expect(stream.fileList).toContain('.changeset/config.json')

--- a/template/.husky/commit-msg
+++ b/template/.husky/commit-msg
@@ -1,1 +1,1 @@
-pnpm exec validate-conventional-commit < .git/COMMIT_EDITMSG
+<%= npmClient %> exec validate-conventional-commit < "$1"

--- a/template/.husky/pre-commit
+++ b/template/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm exec lint-staged
+<%= npmClient %> exec lint-staged


### PR DESCRIPTION
## Summary

- Generate `commit-msg` hooks that read Git's commit message file argument (`$1`) instead of hardcoding `.git/COMMIT_EDITMSG`.
- Generate `pre-commit` hooks with the selected package manager instead of always using `pnpm`.
- Add generator coverage for the rendered Husky hook commands for both `pnpm` and `npm`.

## Why

Hardcoding `.git/COMMIT_EDITMSG` breaks in linked worktrees because `.git` is a file there, not a directory. Git passes the commit message file path to `commit-msg` hooks as `$1`, and Husky forwards that argument to the project hook body.

The template also supports both `pnpm` and `npm`, so the generated `pre-commit` hook should use the selected package manager.

## Validation

- `npm test`
- `npm run lint`

Tests were run with a temporary `HOME` inside the checkout so SAO's local config writes stayed out of the host preferences directory.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `husky` hooks portable and package-manager aware. Fixes commit message validation in Git worktrees and aligns pre-commit with the selected client.

- **Bug Fixes**
  - `commit-msg` hook now reads the Git-provided path `$1` instead of `.git/COMMIT_EDITMSG`.
  - `pre-commit` hook now uses the selected package manager (`pnpm` or `npm`) via `<%= npmClient %>`.

<sup>Written for commit 000ab228b5f25683ba0eed7b573bf825f3a09c99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/create-node-lib/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

